### PR TITLE
Release 4.4.9

### DIFF
--- a/invn/soniclib/ch_api.c
+++ b/invn/soniclib/ch_api.c
@@ -1338,3 +1338,7 @@ uint8_t ch_check_reset_state(ch_dev_t *dev_ptr, ch_sensor_reset_state_t *reset_s
 
 	return ret_val;
 }
+
+uint32_t ch_measure_pmut_frequency(ch_dev_t *dev_ptr) {
+    return ch_common_measure_pmut_frequency(dev_ptr);
+}

--- a/invn/soniclib/ch_driver.c
+++ b/invn/soniclib/ch_driver.c
@@ -1291,6 +1291,7 @@ static void clock_init(ch_dev_t *dev_ptr, uint8_t restart) {
 	if (restart) {  // if restart, use values already in ch_dev_t
 		clock_ctrl.cpu_trim  = dev_ptr->cpu_trim;
 		clock_ctrl.pmut_trim = dev_ptr->pmut_trim;
+		clock_ctrl.control   = dev_ptr->pmut_clk_cfg;
 
 	} else {
 		clock_ctrl.cpu_trim  = SHASTA_CPU_TRIM_DEFAULT;  // normal start - use default values, will do auto cal later

--- a/invn/soniclib/details/ch_common.h
+++ b/invn/soniclib/details/ch_common.h
@@ -341,6 +341,19 @@ uint32_t ch_common_ticks_to_usec(const ch_dev_t *dev_ptr, uint16_t num_rtc_perio
 
 uint16_t ch_common_get_num_output_samples(ch_dev_t *dev_ptr);
 
+/*!
+ * \brief Measure PMUT frequency on an ICU device.
+ *
+ * \param dev_ptr 		pointer to the ch_dev_t config structure for a sensor
+ *
+ * \return PMUT operating frequency in Hz
+ *
+ * This function must only be called after initialization (ie after calling ch_group_start()).
+ */
+/*!
+ */
+uint32_t ch_common_measure_pmut_frequency(ch_dev_t *dev_ptr);
+
 #ifdef __cplusplus
 }
 #endif

--- a/invn/soniclib/soniclib.h
+++ b/invn/soniclib/soniclib.h
@@ -113,7 +113,7 @@ extern "C" {
 /* SonicLib API/Driver version */
 #define SONICLIB_VER_MAJOR  (4) /*!< SonicLib major version. */
 #define SONICLIB_VER_MINOR  (4) /*!< SonicLib minor version. */
-#define SONICLIB_VER_REV    (7) /*!< SonicLib revision. */
+#define SONICLIB_VER_REV    (9) /*!< SonicLib revision. */
 #define SONICLIB_VER_SUFFIX ""  /*!< SonicLib version suffix (contains pre-release info) */
 
 /***** DO NOT MODIFY ANY VALUES BEYOND THIS POINT! *****/
@@ -372,9 +372,12 @@ typedef enum {
 
 //! PMUT clock configuration (ICU sensors)
 typedef enum {
-	CH_PMUT_CLK_DEFAULT       = 0, /*!< Standard PMUT clock config - MUTCLK pad disabled. */
-	CH_PMUT_CLK_OUTPUT_ENABLE = 1, /*!< Output PMUT clock signal on MUTCLK */
-	CH_PMUT_CLK_SRC_EXTERNAL  = 2, /*!< Use external input as PMUT clock source */
+	CH_PMUT_CLK_DEFAULT = 0, /*!< Standard PMUT clock config - MUTCLK pad disabled. */
+	CH_PMUT_CLK_OUTPUT_ENABLE =
+			1, /*!< Output PMUT clock signal on MUTCLK. This option forces MUTCLK on regardless of sensor state. */
+	CH_PMUT_CLK_SRC_EXTERNAL = 2, /*!< Use external input as PMUT clock source */
+	CH_PMUT_CLK_OUTPUT_AUTO =
+			3, /*!< Output PMUT clock signal on MUTCLK but allow ICU device to control the power state */
 } ch_pmut_clk_cfg_t;
 
 //! I/O blocking mode flags.
@@ -4078,8 +4081,16 @@ uint16_t ch_get_rtc_frequency(ch_dev_t *dev_ptr);
  * default CH_PMUT_CLK_DEFAULT configuration.)
  *
  * - To enable output of the sensor's PMUT clock on the MUTCLK pad, set \a clock_cfg
- * to CH_PMUT_CLK_OUTPUT_ENABLE.  The output frequency of the signal on the pad
- * will be 16 times the sensor's acoustic operating frequency.
+ * to CH_PMUT_CLK_OUTPUT_AUTO or CH_PMUT_CLK_OUTPUT_ENABLE. The AUTO setting allows
+ * the ICU part to control the power state of the clock. In this case, the clock
+ * will only be available while the ICU part is actively performing a measurement.
+ * This is a good option to use when multiple parts will be active simultaneously.
+ * The ENABLE option will unconditionally force the clock on. This can be used
+ * in situations where the clock should be available even if the part providing it
+ * is inactive, such as during transmit optimization.
+ *
+ * - The output frequency of the signal on the pad will be 16 times the sensor's
+ * acoustic operating frequency.
  *
  * - To use an input signal on the MUTCLK pad as the external PMUT clock source,
  * set \a clock_cfg to CH_PMUT_CLK_SRC_EXTERNAL.  In this configuration, the
@@ -4092,7 +4103,7 @@ uint16_t ch_get_rtc_frequency(ch_dev_t *dev_ptr);
  * enabling and disabling the clock settings across the sensors is important.
  * The clock source must be present whenever a secondary sensor is
  * configured to use an external clock source.
- * - When enabling, the clock source sensor should be set to
+ * - When enabling, the clock source sensor should be set to CH_PMUT_CLK_OUTPUT_AUTO or
  *   CH_PMUT_CLK_OUTPUT_ENABLE first, then the other sensor(s) should
  *   be set to CH_PMUT_CLK_SRC_EXTERNAL.
  * - When disabling, the secondary sensor(s) should be set to CH_PMUT_CLK_DEFAULT
@@ -4433,6 +4444,20 @@ uint8_t ch_watchdog_disable(ch_dev_t *dev_ptr);
  *
  */
 uint8_t ch_check_reset_state(ch_dev_t *dev_ptr, ch_sensor_reset_state_t *reset_state_ptr);
+
+
+/*!
+ * \brief Measure PMUT frequency on an ICU device.
+ *
+ * \param dev_ptr 		pointer to the ch_dev_t config structure for a sensor
+ *
+ * \return PMUT operating frequency in Hz
+ *
+ * This function must only be called after initialization (ie after calling ch_group_start()).
+ */
+/*!
+ */
+uint32_t ch_measure_pmut_frequency(ch_dev_t *dev_ptr);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
* Support OUTPUT_AUTO clock mode for enabling PMUT external clock with clock power state controlled by ICU ASIC. 
* Expose function to measure PMUT frequency. 
* Restore PMUT clock power state setting in clock_init() in 'restart' condition.