### PR TITLE
Release 4.4.10

### DIFF
--- a/invn/soniclib/ch_api.c
+++ b/invn/soniclib/ch_api.c
@@ -1242,6 +1242,10 @@ uint8_t ch_get_algo_state(ch_dev_t *dev_ptr, void *algo_state_ptr) {
 	return ch_common_get_algo_state(dev_ptr, algo_state_ptr);
 }
 
+uint32_t ch_measure_pmut_frequency(ch_dev_t *dev_ptr) {
+	return ch_common_measure_pmut_frequency(dev_ptr);
+}
+
 #endif  // INCLUDE_SHASTA_SUPPORT
 
 uint32_t ch_get_cpu_frequency(ch_dev_t *dev_ptr) {

--- a/invn/soniclib/ch_driver.c
+++ b/invn/soniclib/ch_driver.c
@@ -1291,6 +1291,7 @@ static void clock_init(ch_dev_t *dev_ptr, uint8_t restart) {
 	if (restart) {  // if restart, use values already in ch_dev_t
 		clock_ctrl.cpu_trim  = dev_ptr->cpu_trim;
 		clock_ctrl.pmut_trim = dev_ptr->pmut_trim;
+		clock_ctrl.control   = dev_ptr->pmut_clk_cfg;
 
 	} else {
 		clock_ctrl.cpu_trim  = SHASTA_CPU_TRIM_DEFAULT;  // normal start - use default values, will do auto cal later

--- a/invn/soniclib/details/ch_common.h
+++ b/invn/soniclib/details/ch_common.h
@@ -341,6 +341,19 @@ uint32_t ch_common_ticks_to_usec(const ch_dev_t *dev_ptr, uint16_t num_rtc_perio
 
 uint16_t ch_common_get_num_output_samples(ch_dev_t *dev_ptr);
 
+/*!
+ * \brief Measure PMUT frequency on an ICU device.
+ *
+ * \param dev_ptr 		pointer to the ch_dev_t config structure for a sensor
+ *
+ * \return PMUT operating frequency in Hz
+ *
+ * This function must only be called after initialization (ie after calling ch_group_start()).
+ */
+/*!
+ */
+uint32_t ch_common_measure_pmut_frequency(ch_dev_t *dev_ptr);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
- Support OUTPUT_AUTO clock mode for enabling PMUT external clock with clock power state controlled by ICU ASIC.
- Expose function to measure PMUT frequency.
- Restore PMUT clock power state setting in clock_init() in 'restart' condition.
- Fix CHX01 build issue (change from 4.4.9)