### PR TITLE
Release 4.6.1.

### DIFF
--- a/invn/soniclib/ch_api.c
+++ b/invn/soniclib/ch_api.c
@@ -1140,6 +1140,11 @@ void ch_meas_get_queue_info(ch_dev_t *dev_ptr, ch_meas_queue_info_t *info_ptr) {
 	ch_common_meas_get_queue_info(dev_ptr, info_ptr);
 }
 
+void ch_inst_get_seg_info(pmut_transceiver_inst_t *inst_ptr, uint8_t odr, ch_meas_seg_info_t *info_ptr) {
+
+	ch_common_inst_get_seg_info(inst_ptr, odr, info_ptr);
+}
+
 void ch_meas_get_seg_info(ch_dev_t *dev_ptr, uint8_t meas_num, uint8_t seg_num, ch_meas_seg_info_t *info_ptr) {
 
 	ch_common_meas_get_seg_info(dev_ptr, meas_num, seg_num, info_ptr);

--- a/invn/soniclib/ch_common.c
+++ b/invn/soniclib/ch_common.c
@@ -80,7 +80,8 @@ uint8_t ch_common_init(ch_dev_t *dev_ptr, ch_group_t *grp_ptr, uint8_t dev_num, 
 		ret_val = (*fw_init_func)(dev_ptr, &dev_ptr->main_fw_info);
 	}
 #else
-	dev_ptr->main_fw_init_done = 0;
+	dev_ptr->main_fw_init_done   = 0;
+	dev_ptr->mq_sanitize_enabled = 1;
 	/* Call asic f/w init function passed in as parameter */
 	ret_val = (*fw_init_func)(dev_ptr, &dev_ptr->main_fw_info);
 #endif
@@ -2636,10 +2637,7 @@ void ch_common_meas_get_info(ch_dev_t *dev_ptr, uint8_t meas_num, ch_meas_info_t
 	info_ptr->odr         = (ch_odr_t)meas_ptr->odr;
 }
 
-void ch_common_meas_get_seg_info(ch_dev_t *dev_ptr, uint8_t meas_num, uint8_t seg_num, ch_meas_seg_info_t *info_ptr) {
-	pmut_transceiver_inst_t *inst_ptr =
-			(pmut_transceiver_inst_t *)&(dev_ptr->meas_queue.meas[meas_num].trx_inst[seg_num]);
-	ch_odr_t odr        = (ch_odr_t)dev_ptr->meas_queue.meas[meas_num].odr;
+void ch_common_inst_get_seg_info(pmut_transceiver_inst_t *inst_ptr, uint8_t odr, ch_meas_seg_info_t *info_ptr) {
 	uint16_t cmd_config = inst_ptr->cmd_config;
 	ch_meas_seg_type_t seg_type;
 
@@ -2662,6 +2660,13 @@ void ch_common_meas_get_seg_info(ch_dev_t *dev_ptr, uint8_t meas_num, uint8_t se
 		info_ptr->rx_gain        = ((cmd_config >> PMUT_RXGAIN_RED_BITSHIFT) & PMUT_RXGAIN_BM);
 		info_ptr->rx_atten       = ((cmd_config >> PMUT_RXATTEN_BITSHIFT) & PMUT_RXATTEN_BM);
 	}
+}
+
+void ch_common_meas_get_seg_info(ch_dev_t *dev_ptr, uint8_t meas_num, uint8_t seg_num, ch_meas_seg_info_t *info_ptr) {
+	pmut_transceiver_inst_t *inst_ptr =
+			(pmut_transceiver_inst_t *)&(dev_ptr->meas_queue.meas[meas_num].trx_inst[seg_num]);
+	ch_odr_t odr = (ch_odr_t)dev_ptr->meas_queue.meas[meas_num].odr;
+	ch_common_inst_get_seg_info(inst_ptr, odr, info_ptr);
 }
 
 void ch_common_meas_get_queue_info(ch_dev_t *dev_ptr, ch_meas_queue_info_t *info_ptr) {

--- a/invn/soniclib/ch_driver.c
+++ b/invn/soniclib/ch_driver.c
@@ -1055,23 +1055,9 @@ static uint8_t limit_rx_len(volatile measurement_t *meas, int rx_len, int eof_id
 	}
 }
 
-//! Adjust the rx length so that it's compatible with continuous RX
-/*! In continuous RX mode, the total RX length must be set to an integer number
- * of RX samples. The number of RX samples given RX length (in SMCLK cycles)
- * depends on the ODR. This function will truncate the RX length such that the
- * new length satisfies the integer number of samples condition.
- *
- * This also prevents glitches with non-continuous RX at certain RX
- * lengths, though not strictly required.
- *
- * \param meas a pointer to a measurement_t. The instructions contained in the
- * measurement_t will be potentially modified by this function.
- * \param rx_len the total rx length in SMCLK cycles
- * \param eof_idx the index of the EOF instruction
- */
-static uint8_t adjust_rx_len(volatile measurement_t *meas, int rx_len, int eof_idx) {
-	const int rx_samples = rx_len >> (11 - meas->odr);
-	const int new_rx_len = rx_samples << (11 - meas->odr);
+uint8_t chdrv_adjust_rx_len(volatile pmut_transceiver_inst_t *trx_inst, uint8_t cic_odr, int rx_len, int eof_idx) {
+	const int rx_samples = rx_len >> (11 - cic_odr);
+	const int new_rx_len = rx_samples << (11 - cic_odr);
 	int len_to_cut       = rx_len - new_rx_len;
 
 	CH_LOG_DEBUG("rx_len=%d rx_samples=%d new_rx_len=%d len_to_cut=%d", rx_len, rx_samples, new_rx_len, len_to_cut);
@@ -1079,15 +1065,31 @@ static uint8_t adjust_rx_len(volatile measurement_t *meas, int rx_len, int eof_i
 	if (len_to_cut == 0) {
 		// No modification needed for this rx instruction
 		return 0;
-	} else if (meas->trx_inst[eof_idx - 1].length >= (1 << (11 - meas->odr)) + len_to_cut) {
+	} else if (trx_inst[eof_idx - 1].length >= (1 << (11 - cic_odr)) + len_to_cut) {
 		// make sure resulting rx instruction will have at least one RX sample left
 		// in it after the cut.
-		meas->trx_inst[eof_idx - 1].length -= len_to_cut;
+		trx_inst[eof_idx - 1].length -= len_to_cut;
 		return 0;
 	} else {
 		// return error otherwise
 		return 1;
 	}
+}
+
+static uint8_t adjust_rx_len(volatile measurement_t *meas, int rx_len, int eof_idx) {
+	return chdrv_adjust_rx_len(meas->trx_inst, meas->odr, rx_len, eof_idx);
+}
+
+void chdrv_enable_mq_sanitize(ch_dev_t *dev_ptr) {
+	dev_ptr->mq_sanitize_enabled = 1;
+}
+
+void chdrv_disable_mq_sanitize(ch_dev_t *dev_ptr) {
+	dev_ptr->mq_sanitize_enabled = 0;
+}
+
+int16_t chdrv_is_mq_sanitize_enabled(const ch_dev_t *dev_ptr) {
+	return dev_ptr->mq_sanitize_enabled;
 }
 
 //! Sanitize the measurement queue
@@ -1187,12 +1189,14 @@ uint8_t chdrv_meas_queue_write(ch_dev_t *dev_ptr, measurement_queue_t *q_buf_ptr
 	if (q_buf_ptr == NULL) {
 		q_buf_ptr = &(dev_ptr->meas_queue);  // source is local copy in ch_dev_t
 	}
-	// Note that we do not abort the write when the sanitize funciton returns an
-	// error. This is mostly for historical reasons. We have previously allowed
-	// writing invalid queues. It is OK to write them so long as they are not
-	// used, and it's a bit confusing for us to just arbitrarily set them when
-	// the user has not requested it
-	meas_queue_sanitize(q_buf_ptr, dev_ptr->current_fw->max_samples);
+	if (chdrv_is_mq_sanitize_enabled(dev_ptr)) {
+		// Note that we do not abort the write when the sanitize funciton returns an
+		// error. This is mostly for historical reasons. We have previously allowed
+		// writing invalid queues. It is OK to write them so long as they are not
+		// used, and it's a bit confusing for us to just arbitrarily set them when
+		// the user has not requested it
+		meas_queue_sanitize(q_buf_ptr, dev_ptr->current_fw->max_samples);
+	}
 	err |= chdrv_burst_write(dev_ptr, meas_queue_addr, (uint8_t *)q_buf_ptr, sizeof(measurement_queue_t));
 
 	return err;
@@ -2415,9 +2419,18 @@ static inline uint8_t shasta_detect_and_program(ch_dev_t *dev_ptr) {
 		if (!ch_err) {
 			ch_err = chdrv_read_buf_addr(dev_ptr);
 		}
+		if (!ch_err) {
+			uint16_t ver_major_addr = (uint16_t)(uintptr_t)&dev_ptr->sens_cfg_addr->common.reg_map_format.major;
+			uint16_t ver_minor_addr = (uint16_t)(uintptr_t)&dev_ptr->sens_cfg_addr->common.reg_map_format.minor;
+			ch_err                  = chdrv_read_byte(dev_ptr, ver_major_addr, &dev_ptr->reg_fmt_ver_major);
+			if (!ch_err) {
+				ch_err = chdrv_read_byte(dev_ptr, ver_minor_addr, &dev_ptr->reg_fmt_ver_minor);
+			}
+		}
 
 		CH_LOG_INFO("Sensor shared mem addr = 0x%04x", (uint16_t)(uintptr_t)dev_ptr->sens_cfg_addr);
 		CH_LOG_INFO("Sensor algo info addr = 0x%04x", (uint16_t)(uintptr_t)dev_ptr->sens_algo_info_addr);
+		CH_LOG_INFO("Sensor register map version = %u.%u", dev_ptr->reg_fmt_ver_major, dev_ptr->reg_fmt_ver_minor);
 	}
 
 	/* Copy OTP (one-time-programmable) mem contents to sensor ram and process contents.

--- a/invn/soniclib/details/ch_common.h
+++ b/invn/soniclib/details/ch_common.h
@@ -262,6 +262,7 @@ uint8_t ch_common_meas_switch(ch_dev_t *dev_ptr);
 uint8_t ch_common_meas_get_last_num(ch_dev_t *dev_ptr);
 void ch_common_meas_get_info(ch_dev_t *dev_ptr, uint8_t meas_num, ch_meas_info_t *info_ptr);
 void ch_common_meas_get_queue_info(ch_dev_t *dev_ptr, ch_meas_queue_info_t *info_ptr);
+void ch_common_inst_get_seg_info(pmut_transceiver_inst_t *inst_ptr, uint8_t odr, ch_meas_seg_info_t *info_ptr);
 void ch_common_meas_get_seg_info(ch_dev_t *dev_ptr, uint8_t meas_num, uint8_t seg_num, ch_meas_seg_info_t *info_ptr);
 uint8_t ch_common_meas_set_interval(ch_dev_t *dev_ptr, uint8_t meas_num, uint16_t interval_ms);
 uint8_t ch_common_meas_set_interval_us(ch_dev_t *dev_ptr, uint8_t meas_num, uint32_t interval_us);

--- a/invn/soniclib/soniclib.h
+++ b/invn/soniclib/soniclib.h
@@ -112,8 +112,8 @@ extern "C" {
 /*==============  SonicLib Version Info ===================*/
 /* SonicLib API/Driver version */
 #define SONICLIB_VER_MAJOR  (4) /*!< SonicLib major version. */
-#define SONICLIB_VER_MINOR  (5) /*!< SonicLib minor version. */
-#define SONICLIB_VER_REV    (4) /*!< SonicLib revision. */
+#define SONICLIB_VER_MINOR  (6) /*!< SonicLib minor version. */
+#define SONICLIB_VER_REV    (1) /*!< SonicLib revision. */
 #define SONICLIB_VER_SUFFIX ""  /*!< SonicLib version suffix (contains pre-release info) */
 
 /***** DO NOT MODIFY ANY VALUES BEYOND THIS POINT! *****/
@@ -784,6 +784,10 @@ struct ch_dev_t {
 	ch_clock_cal_t test_clock_cal; /*!< Clock calibration values from factory test */
 
 	int16_t data_validation_counter; /*!< Counter value for data validation */
+	int16_t mq_sanitize_enabled;     /* !< Perform mq sanitization step when non-zero */
+
+	uint8_t reg_fmt_ver_major; /*!< SW defined register format major version */
+	uint8_t reg_fmt_ver_minor; /*!< SW defined register format minor version */
 
 	/* Sensor measurement queue */
 	measurement_queue_t meas_queue; /*!< Sensor measurement queue (local copy) */
@@ -3456,6 +3460,31 @@ void ch_meas_get_queue_info(ch_dev_t *dev_ptr, ch_meas_queue_info_t *info_ptr);
  * - rx_atten - attenuation (receive segments only)
  */
 void ch_meas_get_seg_info(ch_dev_t *dev_ptr, uint8_t meas_num, uint8_t seg_num, ch_meas_seg_info_t *info_ptr);
+
+/*!
+ * \brief Get configuration information for a measurement segment.
+ *
+ * \param inst_ptr 		pointer to the pmut_transciever_t instruction
+ * \param odr           measurement odr
+ * \param info_ptr		pointer to ch_meas_seg_info_t structure to be updated
+ *
+ * \return 0 if success, 1 if error
+ *
+ * This function obtains configuration information for the measurement segment specified
+ * by \a inst_ptr.
+ *
+ * The ch_meas_seg_info_t structure specified by \a info_ptr will be completed with the
+ * settings for the measurement segment, including:
+ * - num_rx_samples - length in sample periods (determined by num_cycles and output data rate)
+ * - num_cycles - length in cycles
+ * - rdy_int_en - sensor will interrupt when ready
+ * - done_int_en - sensor will interrupt when done with segment
+ * - tx_phase - phase (transmit segments only)
+ * - tx_pulse_width - pulse width (transmit segments only)
+ * - rx_gain_reduce - gain reduction (receive segments only)
+ * - rx_atten - attenuation (receive segments only)
+ */
+void ch_inst_get_seg_info(pmut_transceiver_inst_t *inst_ptr, uint8_t odr, ch_meas_seg_info_t *info_ptr);
 
 /*!
  * \brief Set the repeat interval for a measurement, in milliseconds.


### PR DESCRIPTION
## New features

* Add API function for getting info from an instruction pointer directly instead of requiring the device pointer
* (Backend) Allow for disabling measurement queue sanitization. This is not intended for public API usage but as a back-door for certain ASIC firmware plugins.