### PR TITLE
fixed check for whitney targets in chdr_group_prepare()

### DIFF
--- a/invn/soniclib/ch_driver.c
+++ b/invn/soniclib/ch_driver.c
@@ -2665,10 +2665,10 @@ int chdrv_group_prepare(ch_group_t *grp_ptr) {
 			grp_ptr->queue[i].running      = 0;
 		}
 
+#ifdef INCLUDE_SHASTA_SUPPORT
 		grp_ptr->sensor_int_pin  = CHIRP_SENSOR_INT_PIN;
 		grp_ptr->sensor_trig_pin = CHIRP_SENSOR_TRIG_PIN;
-
-#ifdef INCLUDE_WHITNEY_SUPPORT
+#elif defined(INCLUDE_WHITNEY_SUPPORT)
 		ch_err = chbsp_i2c_init();
 #endif
 	}


### PR DESCRIPTION
In the implementation of the hardware initialising function, `chdrv_group_prepare(ch_group_t *grp_ptr)` in [soniclib/ch_driver.c](https://github.com/tdk-invn-oss/ultrasonic.soniclib/blob/main/invn/soniclib/ch_driver.c), the default code path has an access to the members `grp_ptr->sensor_int_pin` and `grp_ptr->sensor_trig_pin` which are only defined for shasta targets. Therefore compilation fails for whitney targets since the access occurs before the `#ifdef INCLUDE_WHITNEY_SUPPORT` check, and `CHIRP_SENSOR_INT_PIN` and `CHIRP_SENSOR_TRIG_PIN` are undefined for whitney targets at compile time. 

```c
grp_ptr->sensor_int_pin  = CHIRP_SENSOR_INT_PIN;
grp_ptr->sensor_trig_pin = CHIRP_SENSOR_TRIG_PIN;

#ifdef INCLUDE_WHITNEY_SUPPORT
		ch_err = chbsp_i2c_init();
#endif
```

I have added the following logic to check target definition and pick the appropriate initialization or each in [soniclib/ch_driver.c](https://github.com/tdk-invn-oss/ultrasonic.soniclib/blob/main/invn/soniclib/ch_driver.c).
```c
#ifdef INCLUDE_SHASTA_SUPPORT
		grp_ptr->sensor_int_pin  = CHIRP_SENSOR_INT_PIN;
		grp_ptr->sensor_trig_pin = CHIRP_SENSOR_TRIG_PIN;
#elif defined(INCLUDE_WHITNEY_SUPPORT)
		ch_err = chbsp_i2c_init();
#endif
```
